### PR TITLE
✨ Add CI workflow and update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,26 @@
-<!-- 
-Put one of these emojis in your title to indicate the type of PR:
+<!-- PR title emoji:
 - 🎣 Bug fix
 - 🐋 New feature
 - 📜 Documentation
+- ✨ General improvement
 -->
 
-Fixes # 
+<!-- Related issues:
+Closes #
+Ref #
+-->
 
 ## Summary
 
-<-- Explain the goal of your PR  -->
+<!-- Explain the goal of this PR (WHY) -->
 
-## Changes
+## Key Changes
 
-<-- Explain the changes in your PR -->
+<!-- List the key changes in this PR (WHAT) -->
 
-## Submitter checklist
+## Checklist
 
 - [ ] Add the correct emoji to the PR title
-- [ ] Link the issue number to *Fixes #*
-- [ ] Add summary and explain changes in the PR description
-- [ ] Rebase branch to HEAD
-- [ ] Squash changes into one signed, single commit [^1]
-
-[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
+- [ ] Related issue linked above, if any
+- [ ] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
+- [ ] Changes are minimal and focused

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,22 @@
+name: ci
+
+on:
+  pull_request:
+    branches:
+      - "**"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: pnpm/action-setup@v5
+      - run: |
+          pnpm install
+          pnpm build


### PR DESCRIPTION
## Summary

Add a GitHub Actions CI workflow and streamline the pull request template
to improve the contributor experience.

## Key Changes

- Add a CI workflow (`ci.yaml`) that runs `pnpm install && pnpm build` on
  all pull requests using Node 24 on Ubuntu 24.04
- Simplify the PR template with clearer section headings and concise
  instructions
- Add a "General improvement" emoji option to the PR title guide
- Replace the old submitter checklist with a focused checklist that
  references conventional commits

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused