### PR TITLE
✨ Update site title links, edit URL, and wrangler config for docs repo

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -60,6 +60,9 @@ The primary entry point for Kubetail is the kubetail CLI tool, which can launch 
         src: './src/assets/logo.svg',
         replacesTitle: true,
       },
+      components: {
+        SiteTitle: './src/components/SiteTitle.astro',
+      },
       customCss: [
         './src/styles/global.css',
       ],
@@ -72,7 +75,7 @@ The primary entry point for Kubetail is the kubetail CLI tool, which can launch 
         },
       ],
       editLink: {
-        baseUrl: 'https://github.com/kubetail-org/website/edit/main/',
+        baseUrl: 'https://github.com/kubetail-org/kubetail-docs/edit/main/',
       },
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/kubetail-org/kubetail' },

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -1,0 +1,62 @@
+---
+import { logos } from 'virtual:starlight/user-images';
+import config from 'virtual:starlight/user-config';
+---
+
+<div class="site-title sl-flex">
+	<a href="https://www.kubetail.com" class="logo-link">
+		{
+			config.logo && logos.dark && (
+				<img
+					alt={config.logo.alt}
+					src={logos.dark.src}
+					width={logos.dark.width}
+					height={logos.dark.height}
+				/>
+			)
+		}
+	</a>
+	<a href="/concepts/introduction" class="docs-link" translate="no">DOCS</a>
+</div>
+
+<style>
+	@layer starlight.core {
+		.site-title {
+			align-items: center;
+			gap: var(--sl-nav-gap);
+			font-size: var(--sl-text-h4);
+			font-weight: 600;
+			color: var(--sl-color-text-accent);
+			text-decoration: none;
+			white-space: nowrap;
+			min-width: 0;
+		}
+		.logo-link {
+			display: flex;
+			align-items: center;
+			text-decoration: none;
+		}
+		img {
+			height: calc(var(--sl-nav-height) - 2 * var(--sl-nav-pad-y));
+			width: auto;
+			max-width: 100%;
+			object-fit: contain;
+			object-position: 0 50%;
+		}
+		.docs-link {
+			font-size: .8em;
+			font-weight: 800;
+			letter-spacing: 0.05em;
+			opacity: .45;
+			text-decoration: none;
+			color: inherit;
+			margin-left: -.7rem;
+			margin-bottom: -0.3rem;
+		}
+		@media (max-width: 49.99em) {
+			.docs-link {
+				margin-bottom: calc(-0.3rem + 1px);
+			}
+		}
+	}
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,13 +27,4 @@
   @apply whitespace-nowrap;
 }
 
-.site-title::after {
-  content: 'DOCS';
-  font-size: .8em;
-  font-weight: 800;
-  letter-spacing: 0.05em;
-  margin-left: -.7rem;  
-  margin-bottom: -0.3rem;
-  opacity: .45;
-}
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,8 +1,11 @@
 {
   "main": "dist/_worker.js/index.js",
-  "name": "kubetail-website",
+  "name": "kubetail-docs",
   "routes": [
-    { "pattern": "docs.kubetail.com", "custom_domain": true },
+    {
+      "pattern": "docs.kubetail.com",
+      "custom_domain": true
+    },
   ],
   "compatibility_date": "2026-02-27",
   "compatibility_flags": [


### PR DESCRIPTION
## Summary

Updates the docs site header, edit links, and Cloudflare worker config to properly reflect the standalone kubetail-docs repository.

## Key Changes

- Split the site title into two separate links: the logo now links to kubetail.com and "DOCS" links to `/concepts/introduction`
- Fix the "edit this page" link to point to the `kubetail-docs` repo instead of the old `website` repo
- Rename the Cloudflare worker from `kubetail-website` to `kubetail-docs`

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused