### PR TITLE
🎣 Add compatibility date to wranger.jsonc

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,6 +6,7 @@
 			"custom_domain": true
 		}
 	],
+	"compatibility_date":"2026-04-14",
 	"assets": {
 		"directory": "./dist",
 		"html_handling": "drop-trailing-slash",


### PR DESCRIPTION
## Summary

Add missing compatibility date to wranger.jsonc.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused
