### PR TITLE
📜 Document allowed-origins and session key-pairs

### DIFF
--- a/src/content/docs/guides/cluster/ingress.mdx
+++ b/src/content/docs/guides/cluster/ingress.mdx
@@ -86,7 +86,7 @@ kubetail:
 ```
 
 <Aside type="tip">
-When you serve the Dashboard over HTTPS, set `session.cookie.secure: true` in the Dashboard's `runtimeConfig` so the session cookie is only transmitted over secure connections:
+When you serve the Dashboard over HTTPS, set `session.cookie.secure: true` in the Dashboard's `runtimeConfig` so the session cookie is only transmitted over secure connections. It's also good practice to use a `__Host-` prefix for the cookie name.
 
 ```yaml
 kubetail:
@@ -94,7 +94,20 @@ kubetail:
     runtimeConfig:
       session:
         cookie:
+          name: __Host-session
           secure: true
+```
+</Aside>
+
+<Aside type="tip">
+When you deploy the Dashboard behind a proxy, some requests may fail same-origin checks (e.g. if host ≠ origin) and get rejected (e.g. WebSocket connections). To fix this you can use the `allowedOrigins` option:
+
+```yaml
+kubetail:
+  dashboard:
+    runtimeConfig:
+      allowedOrigins:
+        - https://kubetail.example.com
 ```
 </Aside>
 

--- a/src/content/docs/guides/cluster/installation.mdx
+++ b/src/content/docs/guides/cluster/installation.mdx
@@ -44,16 +44,7 @@ kubectl get pods -n kubetail-system
 
 ## Next Steps
 
-Once Kubetail is running inside your cluster, you can access it using your usual access methods such as `kubectl proxy` or `kubectl port-forward`:
-
-* **`kubectl proxy`**
-
-  ```sh
-  kubectl proxy
-  ```
-
-  Visit [http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/](http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/)
-
+Once Kubetail is running inside your cluster, you can access it using your usual access methods such as `kubectl port-forward`:
 
 * **`kubectl port-forward`**
 
@@ -63,7 +54,7 @@ Once Kubetail is running inside your cluster, you can access it using your usual
 
   Visit [http://localhost:8080](http://localhost:8080)
 
-To make the Kubetail web dashboard easier to access you can also expose it using a service or an ingress.
+To make the Kubetail web dashboard easier to access you can also expose it using an `Ingress` or `GatewayAPI` route (see [Ingress](/guides/cluster/ingress)).
 
 For more information about the Kubetail Dashboard, check out the documentation [here](/dashboard).
 

--- a/src/content/docs/reference/cluster-api.mdx
+++ b/src/content/docs/reference/cluster-api.mdx
@@ -152,20 +152,6 @@ cluster-api --config /etc/kubetail/cluster-api.yaml
         #
         server-name: ""
 
-    ## csrf ##
-    #
-    # CSRF protection settings
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # Whether CSRF protection is enabled.
-      #
-      # Default value: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # Configuration for the API server's logging output

--- a/src/content/docs/reference/dashboard.mdx
+++ b/src/content/docs/reference/dashboard.mdx
@@ -65,6 +65,28 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     allowed-namespaces: []
 
+    ## allowed-origins ##
+    #
+    # Additional origins (in addition to same-origin) accepted on WebSocket
+    # upgrade requests. Each entry must be a fully-qualified origin —
+    # scheme://host[:port] with no path. Comparison is case-insensitive on
+    # host and normalizes default ports (so https://example.com matches
+    # https://example.com:443).
+    #
+    # Use this when running the dashboard behind a reverse proxy that
+    # rewrites Host or terminates TLS without preserving scheme — direct
+    # same-origin matching against r.Host/r.TLS would otherwise reject
+    # legitimate browser requests. List the public-facing origin(s) the
+    # dashboard is served at.
+    #
+    # Examples:
+    #   - https://kubetail.example.com
+    #   - https://kubetail.example.com:8443
+    #
+    # Default value: []
+    #
+    allowed-origins: []
+
     ## kubeconfig ##
     #
     # Path to the kubeconfig file to use for Kubernetes API requests.
@@ -126,20 +148,6 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     gin-mode: release
 
-    ## csrf ##
-    #
-    # CSRF protection settings
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # Whether CSRF protection is enabled.
-      #
-      # Default value: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # Configuration for the dashboard server's logging output
@@ -200,15 +208,20 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     session:
 
-      ## secret ##
+      ## key-pairs ##
       #
-      # The secret key used to sign session tokens.
-      # If empty, a random secret is generated on startup (sessions will not
-      # survive restarts).
+      # One or more signing/encryption key pairs for session cookies. The first
+      # pair is used for new cookies; additional pairs are accepted for reading
+      # only, enabling zero-downtime key rotation.
       #
-      # Default value: ""
+      # Each pair has:
+      #   signing-key    (required) — hex-encoded HMAC signing key; 32 or 64 raw bytes recommended
+      #   encryption-key (optional) — hex-encoded AES encryption key; 16, 24, or 32 raw bytes
       #
-      secret: ""
+      # When empty and a local-storage-dir is configured, a random pair is
+      # generated and persisted to disk on first startup.
+      #
+      key-pairs: []
 
       ## cookie ##
       #


### PR DESCRIPTION
## Summary

Updates the dashboard reference and ingress guide to reflect recent configuration changes: a new `allowed-origins` option for proxied deployments, the replacement of `session.secret` with rotatable `session.key-pairs`, and removal of the obsolete `csrf` config block. Also tightens the installation guide.

## Key Changes

- Add `allowed-origins` to the dashboard reference and a matching tip in the ingress guide
- Replace `session.secret` with `session.key-pairs` in the dashboard reference
- Remove obsolete `csrf` config from dashboard and cluster-api references
- Drop the `kubectl proxy` example from installation; link to the Ingress guide for exposure options

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused