### PR TITLE
📜 Sync translations for allowed-origins and session key-pairs

### DIFF
--- a/src/content/docs/de/guides/cluster/ingress.mdx
+++ b/src/content/docs/de/guides/cluster/ingress.mdx
@@ -86,7 +86,7 @@ kubetail:
 ```
 
 <Aside type="tip">
-Wenn Sie das Dashboard ueber HTTPS bereitstellen, setzen Sie `session.cookie.secure: true` in der `runtimeConfig` des Dashboards, damit das Session-Cookie nur ueber sichere Verbindungen uebertragen wird:
+Wenn Sie das Dashboard ueber HTTPS bereitstellen, setzen Sie `session.cookie.secure: true` in der `runtimeConfig` des Dashboards, damit das Session-Cookie nur ueber sichere Verbindungen uebertragen wird. Es empfiehlt sich ausserdem, fuer den Cookie-Namen ein `__Host-`-Praefix zu verwenden.
 
 ```yaml
 kubetail:
@@ -94,7 +94,20 @@ kubetail:
     runtimeConfig:
       session:
         cookie:
+          name: __Host-session
           secure: true
+```
+</Aside>
+
+<Aside type="tip">
+Wenn Sie das Dashboard hinter einem Proxy bereitstellen, koennen einige Anfragen die Same-Origin-Pruefungen nicht bestehen (z. B. wenn Host ungleich Origin ist) und werden abgelehnt (z. B. WebSocket-Verbindungen). Um dies zu beheben, koennen Sie die Option `allowedOrigins` verwenden:
+
+```yaml
+kubetail:
+  dashboard:
+    runtimeConfig:
+      allowedOrigins:
+        - https://kubetail.example.com
 ```
 </Aside>
 

--- a/src/content/docs/de/guides/cluster/installation.mdx
+++ b/src/content/docs/de/guides/cluster/installation.mdx
@@ -44,16 +44,7 @@ kubectl get pods -n kubetail-system
 
 ## Naechste Schritte
 
-Sobald Kubetail in Ihrem Cluster laeuft, koennen Sie wie gewohnt ueber `kubectl proxy` oder `kubectl port-forward` darauf zugreifen:
-
-* **`kubectl proxy`**
-
-  ```sh
-  kubectl proxy
-  ```
-
-  Aufrufen: [http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/](http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/)
-
+Sobald Kubetail in Ihrem Cluster laeuft, koennen Sie ueber Ihre ueblichen Zugriffsmethoden wie `kubectl port-forward` darauf zugreifen:
 
 * **`kubectl port-forward`**
 
@@ -63,7 +54,7 @@ Sobald Kubetail in Ihrem Cluster laeuft, koennen Sie wie gewohnt ueber `kubectl 
 
   Aufrufen: [http://localhost:8080](http://localhost:8080)
 
-Sie koennen das Kubetail-Web-Dashboard auch ueber einen Service oder Ingress exponieren, um den Zugriff zu erleichtern.
+Um den Zugriff auf das Kubetail-Web-Dashboard zu erleichtern, koennen Sie es auch ueber eine `Ingress`- oder `GatewayAPI`-Route exponieren (siehe [Ingress](/de/guides/cluster/ingress)).
 
 Weitere Informationen zum Kubetail-Dashboard finden Sie in der Dokumentation [hier](/de/concepts/gui-overview).
 

--- a/src/content/docs/de/reference/cluster-api.mdx
+++ b/src/content/docs/de/reference/cluster-api.mdx
@@ -152,20 +152,6 @@ cluster-api --config /etc/kubetail/cluster-api.yaml
         #
         server-name: ""
 
-    ## csrf ##
-    #
-    # Einstellungen fuer den CSRF-Schutz
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # Ob CSRF-Schutz aktiviert ist.
-      #
-      # Standardwert: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # Konfiguration fuer die Log-Ausgabe des API-Servers

--- a/src/content/docs/de/reference/dashboard.mdx
+++ b/src/content/docs/de/reference/dashboard.mdx
@@ -65,6 +65,30 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     allowed-namespaces: []
 
+    ## allowed-origins ##
+    #
+    # Zusaetzliche Origins (zusaetzlich zu Same-Origin), die bei
+    # WebSocket-Upgrade-Anfragen akzeptiert werden. Jeder Eintrag muss
+    # ein vollstaendig qualifizierter Origin sein — scheme://host[:port]
+    # ohne Pfad. Der Vergleich erfolgt case-insensitiv beim Host und
+    # normalisiert Standard-Ports (so dass https://example.com mit
+    # https://example.com:443 uebereinstimmt).
+    #
+    # Verwenden Sie dies, wenn das Dashboard hinter einem Reverse-Proxy
+    # betrieben wird, der Host umschreibt oder TLS terminiert, ohne das
+    # Schema zu erhalten — andernfalls wuerde der direkte Same-Origin-
+    # Abgleich gegen r.Host/r.TLS legitime Browser-Anfragen ablehnen.
+    # Listen Sie die oeffentlichen Origins auf, unter denen das Dashboard
+    # bereitgestellt wird.
+    #
+    # Beispiele:
+    #   - https://kubetail.example.com
+    #   - https://kubetail.example.com:8443
+    #
+    # Standardwert: []
+    #
+    allowed-origins: []
+
     ## kubeconfig ##
     #
     # Pfad zur kubeconfig-Datei, die fuer Kubernetes-API-Anfragen verwendet wird.
@@ -126,20 +150,6 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     gin-mode: release
 
-    ## csrf ##
-    #
-    # Einstellungen fuer den CSRF-Schutz
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # Ob CSRF-Schutz aktiviert ist.
-      #
-      # Standardwert: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # Konfiguration fuer die Log-Ausgabe des Dashboard-Servers
@@ -200,15 +210,22 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     session:
 
-      ## secret ##
+      ## key-pairs ##
       #
-      # Der geheime Schluessel, der zum Signieren von Session-Tokens verwendet wird.
-      # Wenn leer, wird beim Start ein zufaelliges Secret generiert (Sessions ueberleben
-      # dann keinen Neustart).
+      # Ein oder mehrere Signing-/Encryption-Schluesselpaare fuer
+      # Session-Cookies. Das erste Paar wird fuer neue Cookies verwendet;
+      # zusaetzliche Paare werden nur zum Lesen akzeptiert, was eine
+      # ausfallfreie Schluesselrotation ermoeglicht.
       #
-      # Standardwert: ""
+      # Jedes Paar enthaelt:
+      #   signing-key    (erforderlich) — hex-kodierter HMAC-Signing-Key; 32 oder 64 Roh-Bytes empfohlen
+      #   encryption-key (optional)     — hex-kodierter AES-Encryption-Key; 16, 24 oder 32 Roh-Bytes
       #
-      secret: ""
+      # Wenn leer und ein local-storage-dir konfiguriert ist, wird beim
+      # ersten Start ein zufaelliges Paar generiert und auf der Festplatte
+      # persistiert.
+      #
+      key-pairs: []
 
       ## cookie ##
       #

--- a/src/content/docs/es/guides/cluster/ingress.mdx
+++ b/src/content/docs/es/guides/cluster/ingress.mdx
@@ -86,7 +86,7 @@ kubetail:
 ```
 
 <Aside type="tip">
-Cuando sirva el Dashboard a traves de HTTPS, establezca `session.cookie.secure: true` en la `runtimeConfig` del Dashboard para que la cookie de sesion solo se transmita a traves de conexiones seguras:
+Cuando sirva el Dashboard a traves de HTTPS, establezca `session.cookie.secure: true` en la `runtimeConfig` del Dashboard para que la cookie de sesion solo se transmita a traves de conexiones seguras. Tambien es buena practica usar el prefijo `__Host-` para el nombre de la cookie.
 
 ```yaml
 kubetail:
@@ -94,7 +94,20 @@ kubetail:
     runtimeConfig:
       session:
         cookie:
+          name: __Host-session
           secure: true
+```
+</Aside>
+
+<Aside type="tip">
+Cuando despliega el Dashboard detras de un proxy, algunas solicitudes pueden fallar las verificaciones de same-origin (por ejemplo, si host ≠ origin) y ser rechazadas (por ejemplo, conexiones WebSocket). Para solucionarlo puede usar la opcion `allowedOrigins`:
+
+```yaml
+kubetail:
+  dashboard:
+    runtimeConfig:
+      allowedOrigins:
+        - https://kubetail.example.com
 ```
 </Aside>
 

--- a/src/content/docs/es/guides/cluster/installation.mdx
+++ b/src/content/docs/es/guides/cluster/installation.mdx
@@ -44,16 +44,7 @@ kubectl get pods -n kubetail-system
 
 ## Siguientes pasos
 
-Una vez que Kubetail este en ejecucion dentro de su cluster, puede acceder a el con sus metodos habituales, como `kubectl proxy` o `kubectl port-forward`:
-
-* **`kubectl proxy`**
-
-  ```sh
-  kubectl proxy
-  ```
-
-  Visite [http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/](http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/)
-
+Una vez que Kubetail este en ejecucion dentro de su cluster, puede acceder a el con sus metodos habituales, como `kubectl port-forward`:
 
 * **`kubectl port-forward`**
 
@@ -63,7 +54,7 @@ Una vez que Kubetail este en ejecucion dentro de su cluster, puede acceder a el 
 
   Visite [http://localhost:8080](http://localhost:8080)
 
-Tambien puede exponer el dashboard web de Kubetail mediante un servicio o un ingress para facilitar el acceso.
+Para facilitar el acceso al dashboard web de Kubetail, tambien puede exponerlo mediante una ruta `Ingress` o `GatewayAPI` (vea [Ingress](/es/guides/cluster/ingress)).
 
 Para obtener mas informacion sobre el Dashboard de Kubetail, consulte la documentacion [aqui](/es/concepts/gui-overview).
 

--- a/src/content/docs/es/reference/cluster-api.mdx
+++ b/src/content/docs/es/reference/cluster-api.mdx
@@ -152,20 +152,6 @@ cluster-api --config /etc/kubetail/cluster-api.yaml
         #
         server-name: ""
 
-    ## csrf ##
-    #
-    # Configuracion de proteccion CSRF
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # Indica si la proteccion CSRF esta habilitada.
-      #
-      # Valor predeterminado: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # Configuracion de la salida de logs del servidor API

--- a/src/content/docs/es/reference/dashboard.mdx
+++ b/src/content/docs/es/reference/dashboard.mdx
@@ -65,6 +65,28 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     allowed-namespaces: []
 
+    ## allowed-origins ##
+    #
+    # Origenes adicionales (ademas de same-origin) aceptados en las solicitudes
+    # de upgrade WebSocket. Cada entrada debe ser un origen totalmente
+    # cualificado — scheme://host[:port] sin path. La comparacion no distingue
+    # mayusculas/minusculas en el host y normaliza los puertos predeterminados
+    # (de modo que https://example.com coincide con https://example.com:443).
+    #
+    # Use esto cuando ejecute el dashboard detras de un proxy inverso que
+    # reescriba Host o termine TLS sin preservar el scheme — la coincidencia
+    # directa de same-origin contra r.Host/r.TLS rechazaria de otro modo
+    # solicitudes legitimas del navegador. Liste los origenes publicos en los
+    # que se sirve el dashboard.
+    #
+    # Ejemplos:
+    #   - https://kubetail.example.com
+    #   - https://kubetail.example.com:8443
+    #
+    # Valor predeterminado: []
+    #
+    allowed-origins: []
+
     ## kubeconfig ##
     #
     # Ruta al archivo kubeconfig que se utilizara para solicitudes a la API de Kubernetes.
@@ -126,20 +148,6 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     gin-mode: release
 
-    ## csrf ##
-    #
-    # Configuracion de proteccion CSRF
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # Indica si la proteccion CSRF esta habilitada.
-      #
-      # Valor predeterminado: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # Configuracion de la salida de logs del servidor del dashboard
@@ -200,15 +208,21 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     session:
 
-      ## secret ##
+      ## key-pairs ##
       #
-      # La clave secreta usada para firmar tokens de sesion.
-      # Si esta vacia, se genera un secreto aleatorio al iniciar (las sesiones no
-      # sobreviviran a los reinicios).
+      # Uno o mas pares de claves de firma/cifrado para las cookies de sesion.
+      # El primer par se usa para nuevas cookies; los pares adicionales se
+      # aceptan solo para lectura, lo que permite la rotacion de claves sin
+      # tiempo de inactividad.
       #
-      # Valor predeterminado: ""
+      # Cada par tiene:
+      #   signing-key    (obligatoria) — clave HMAC de firma codificada en hex; se recomiendan 32 o 64 bytes en bruto
+      #   encryption-key (opcional)    — clave AES de cifrado codificada en hex; 16, 24 o 32 bytes en bruto
       #
-      secret: ""
+      # Cuando esta vacia y se ha configurado un local-storage-dir, se genera
+      # un par aleatorio y se persiste en disco al iniciar por primera vez.
+      #
+      key-pairs: []
 
       ## cookie ##
       #

--- a/src/content/docs/fr/guides/cluster/ingress.mdx
+++ b/src/content/docs/fr/guides/cluster/ingress.mdx
@@ -86,7 +86,7 @@ kubetail:
 ```
 
 <Aside type="tip">
-Lorsque vous servez le Dashboard en HTTPS, definissez `session.cookie.secure: true` dans la `runtimeConfig` du Dashboard afin que le cookie de session ne soit transmis que via des connexions securisees:
+Lorsque vous servez le Dashboard en HTTPS, definissez `session.cookie.secure: true` dans la `runtimeConfig` du Dashboard afin que le cookie de session ne soit transmis que via des connexions securisees. Il est egalement recommande d'utiliser un prefixe `__Host-` pour le nom du cookie.
 
 ```yaml
 kubetail:
@@ -94,7 +94,20 @@ kubetail:
     runtimeConfig:
       session:
         cookie:
+          name: __Host-session
           secure: true
+```
+</Aside>
+
+<Aside type="tip">
+Lorsque vous deployez le Dashboard derriere un proxy, certaines requetes peuvent echouer aux verifications same-origin (par ex. si host ≠ origin) et etre rejetees (par ex. les connexions WebSocket). Pour corriger cela, vous pouvez utiliser l'option `allowedOrigins`:
+
+```yaml
+kubetail:
+  dashboard:
+    runtimeConfig:
+      allowedOrigins:
+        - https://kubetail.example.com
 ```
 </Aside>
 

--- a/src/content/docs/fr/guides/cluster/installation.mdx
+++ b/src/content/docs/fr/guides/cluster/installation.mdx
@@ -44,16 +44,7 @@ kubectl get pods -n kubetail-system
 
 ## Etapes suivantes
 
-Une fois que Kubetail s'execute dans votre cluster, vous pouvez y acceder avec vos methodes habituelles, comme `kubectl proxy` ou `kubectl port-forward`:
-
-* **`kubectl proxy`**
-
-  ```sh
-  kubectl proxy
-  ```
-
-  Consultez [http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/](http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/)
-
+Une fois que Kubetail s'execute dans votre cluster, vous pouvez y acceder avec vos methodes habituelles, comme `kubectl port-forward`:
 
 * **`kubectl port-forward`**
 
@@ -63,7 +54,7 @@ Une fois que Kubetail s'execute dans votre cluster, vous pouvez y acceder avec v
 
   Consultez [http://localhost:8080](http://localhost:8080)
 
-Vous pouvez egalement exposer le dashboard web de Kubetail via un service ou un ingress pour en faciliter l'acces.
+Pour faciliter l'acces au dashboard web de Kubetail, vous pouvez egalement l'exposer via un `Ingress` ou une route `GatewayAPI` (voir [Ingress](/fr/guides/cluster/ingress)).
 
 Pour en savoir plus sur le dashboard Kubetail, consultez la documentation [ici](/fr/concepts/gui-overview).
 

--- a/src/content/docs/fr/reference/cluster-api.mdx
+++ b/src/content/docs/fr/reference/cluster-api.mdx
@@ -152,20 +152,6 @@ cluster-api --config /etc/kubetail/cluster-api.yaml
         #
         server-name: ""
 
-    ## csrf ##
-    #
-    # Parametres de protection CSRF
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # Indique si la protection CSRF est activee.
-      #
-      # Valeur par defaut: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # Configuration de la sortie de logs du serveur API

--- a/src/content/docs/fr/reference/dashboard.mdx
+++ b/src/content/docs/fr/reference/dashboard.mdx
@@ -65,6 +65,28 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     allowed-namespaces: []
 
+    ## allowed-origins ##
+    #
+    # Origines additionnelles (en plus de same-origin) acceptees lors des
+    # requetes d'upgrade WebSocket. Chaque entree doit etre une origine
+    # pleinement qualifiee — scheme://host[:port] sans chemin. La comparaison
+    # est insensible a la casse sur l'hote et normalise les ports par defaut
+    # (ainsi https://example.com correspond a https://example.com:443).
+    #
+    # Utilisez ceci lorsque le dashboard s'execute derriere un reverse proxy
+    # qui reecrit Host ou termine TLS sans preserver le scheme — sinon la
+    # correspondance same-origin directe avec r.Host/r.TLS rejetterait des
+    # requetes navigateur legitimes. Listez la ou les origines publiques
+    # auxquelles le dashboard est servi.
+    #
+    # Exemples:
+    #   - https://kubetail.example.com
+    #   - https://kubetail.example.com:8443
+    #
+    # Valeur par defaut: []
+    #
+    allowed-origins: []
+
     ## kubeconfig ##
     #
     # Chemin vers le fichier kubeconfig a utiliser pour les requetes a l'API Kubernetes.
@@ -126,20 +148,6 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     gin-mode: release
 
-    ## csrf ##
-    #
-    # Parametres de protection CSRF
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # Indique si la protection CSRF est activee.
-      #
-      # Valeur par defaut: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # Configuration de la sortie de logs du serveur dashboard
@@ -200,15 +208,21 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     session:
 
-      ## secret ##
+      ## key-pairs ##
       #
-      # Cle secrete utilisee pour signer les tokens de session.
-      # Si vide, un secret aleatoire est genere au demarrage (les sessions ne
-      # survivront pas aux redemarrages).
+      # Une ou plusieurs paires de cles de signature/chiffrement pour les
+      # cookies de session. La premiere paire est utilisee pour les nouveaux
+      # cookies; les paires supplementaires sont acceptees uniquement en
+      # lecture, ce qui permet une rotation de cles sans interruption.
       #
-      # Valeur par defaut: ""
+      # Chaque paire contient:
+      #   signing-key    (obligatoire) — cle HMAC de signature encodee en hex; 32 ou 64 octets bruts recommandes
+      #   encryption-key (optionnelle) — cle AES de chiffrement encodee en hex; 16, 24 ou 32 octets bruts
       #
-      secret: ""
+      # Si vide et qu'un local-storage-dir est configure, une paire aleatoire
+      # est generee et persistee sur disque au premier demarrage.
+      #
+      key-pairs: []
 
       ## cookie ##
       #

--- a/src/content/docs/ja/guides/cluster/ingress.mdx
+++ b/src/content/docs/ja/guides/cluster/ingress.mdx
@@ -86,7 +86,7 @@ kubetail:
 ```
 
 <Aside type="tip">
-Dashboard を HTTPS で提供する場合は、Dashboard の `runtimeConfig` で `session.cookie.secure: true` を設定し、セッション Cookie が安全な接続でのみ送信されるようにしてください。
+Dashboard を HTTPS で提供する場合は、Dashboard の `runtimeConfig` で `session.cookie.secure: true` を設定し、セッション Cookie が安全な接続でのみ送信されるようにしてください。Cookie 名には `__Host-` プレフィックスを使用するのも良い習慣です。
 
 ```yaml
 kubetail:
@@ -94,7 +94,20 @@ kubetail:
     runtimeConfig:
       session:
         cookie:
+          name: __Host-session
           secure: true
+```
+</Aside>
+
+<Aside type="tip">
+Dashboard をプロキシの背後にデプロイすると、一部のリクエストが same-origin チェックに失敗して（例: host ≠ origin の場合）拒否されることがあります（例: WebSocket 接続）。これを修正するには、`allowedOrigins` オプションを使用できます。
+
+```yaml
+kubetail:
+  dashboard:
+    runtimeConfig:
+      allowedOrigins:
+        - https://kubetail.example.com
 ```
 </Aside>
 

--- a/src/content/docs/ja/guides/cluster/installation.mdx
+++ b/src/content/docs/ja/guides/cluster/installation.mdx
@@ -44,16 +44,7 @@ kubectl get pods -n kubetail-system
 
 ## 次のステップ
 
-Kubetail がクラスタ内で動作したら、通常どおり `kubectl proxy` や `kubectl port-forward` でアクセスできます。
-
-* **`kubectl proxy`**
-
-  ```sh
-  kubectl proxy
-  ```
-
-  [http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/](http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/) にアクセスしてください。
-
+Kubetail がクラスタ内で動作したら、`kubectl port-forward` などの通常のアクセス方法で利用できます。
 
 * **`kubectl port-forward`**
 
@@ -63,7 +54,7 @@ Kubetail がクラスタ内で動作したら、通常どおり `kubectl proxy` 
 
   [http://localhost:8080](http://localhost:8080) にアクセスしてください。
 
-アクセスしやすくするために、Kubetail Web ダッシュボードを Service または Ingress 経由で公開することもできます。
+Kubetail Web ダッシュボードへのアクセスをより容易にするために、`Ingress` または `GatewayAPI` ルートを使って公開することもできます（[Ingress](/ja/guides/cluster/ingress) を参照）。
 
 Kubetail Dashboard の詳細については、[こちらのドキュメント](/ja/concepts/gui-overview) を参照してください。
 

--- a/src/content/docs/ja/reference/cluster-api.mdx
+++ b/src/content/docs/ja/reference/cluster-api.mdx
@@ -152,20 +152,6 @@ cluster-api --config /etc/kubetail/cluster-api.yaml
         #
         server-name: ""
 
-    ## csrf ##
-    #
-    # CSRF 保護設定
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # CSRF 保護を有効にするかどうか
-      #
-      # 既定値: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # API サーバーのログ出力設定

--- a/src/content/docs/ja/reference/dashboard.mdx
+++ b/src/content/docs/ja/reference/dashboard.mdx
@@ -65,6 +65,29 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     allowed-namespaces: []
 
+    ## allowed-origins ##
+    #
+    # WebSocket アップグレードリクエストで（same-origin に加えて）
+    # 受け入れる追加のオリジンです。各エントリは完全修飾オリジン
+    # （scheme://host[:port]、パスなし）である必要があります。比較は
+    # ホストについて大文字小文字を区別せず、デフォルトポートを正規化
+    # します（そのため https://example.com は https://example.com:443
+    # と一致します）。
+    #
+    # Host を書き換えたり scheme を保持せずに TLS を終端するリバース
+    # プロキシの背後で Dashboard を実行する場合にこの設定を使用します。
+    # この場合、r.Host/r.TLS に対する直接の same-origin 一致は正当な
+    # ブラウザリクエストを拒否してしまうためです。Dashboard が提供
+    # される公開向けのオリジンを記載してください。
+    #
+    # 例:
+    #   - https://kubetail.example.com
+    #   - https://kubetail.example.com:8443
+    #
+    # 既定値: []
+    #
+    allowed-origins: []
+
     ## kubeconfig ##
     #
     # Kubernetes API リクエストに使用する kubeconfig ファイルへのパスです。
@@ -126,20 +149,6 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     gin-mode: release
 
-    ## csrf ##
-    #
-    # CSRF 保護設定
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # CSRF 保護を有効にするかどうか
-      #
-      # 既定値: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # dashboard server のログ出力設定
@@ -200,15 +209,21 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     session:
 
-      ## secret ##
+      ## key-pairs ##
       #
-      # セッショントークンの署名に使用する秘密鍵です。
-      # 空の場合は起動時にランダムな secret が生成されます（セッションは
-      # 再起動をまたいで保持されません）。
+      # セッション Cookie 用の署名／暗号化キーペアを 1 つ以上指定します。
+      # 最初のペアは新しい Cookie の生成に使用され、追加のペアは読み取り
+      # のみ受け付けられます。これによりダウンタイムなしでのキーローテー
+      # ションが可能になります。
       #
-      # 既定値: ""
+      # 各ペアの構成:
+      #   signing-key    （必須）— hex エンコードされた HMAC 署名鍵。32 または 64 バイトのバイナリ長を推奨
+      #   encryption-key （任意）— hex エンコードされた AES 暗号化鍵。16、24、32 バイトのバイナリ長
       #
-      secret: ""
+      # 空のとき local-storage-dir が設定されていれば、初回起動時に
+      # ランダムなペアが生成されてディスクに永続化されます。
+      #
+      key-pairs: []
 
       ## cookie ##
       #

--- a/src/content/docs/ko/guides/cluster/ingress.mdx
+++ b/src/content/docs/ko/guides/cluster/ingress.mdx
@@ -86,7 +86,7 @@ kubetail:
 ```
 
 <Aside type="tip">
-Dashboard를 HTTPS로 제공할 때는 Dashboard의 `runtimeConfig`에서 `session.cookie.secure: true`를 설정해 세션 쿠키가 보안 연결에서만 전송되도록 하세요.
+Dashboard를 HTTPS로 제공할 때는 Dashboard의 `runtimeConfig`에서 `session.cookie.secure: true`를 설정해 세션 쿠키가 보안 연결에서만 전송되도록 하세요. 또한 쿠키 이름에 `__Host-` 접두사를 사용하는 것이 좋습니다.
 
 ```yaml
 kubetail:
@@ -94,7 +94,20 @@ kubetail:
     runtimeConfig:
       session:
         cookie:
+          name: __Host-session
           secure: true
+```
+</Aside>
+
+<Aside type="tip">
+Dashboard를 프록시 뒤에 배포하면 일부 요청이 same-origin 검사에 실패해(예: host ≠ origin) 거부될 수 있습니다(예: WebSocket 연결). 이를 해결하려면 `allowedOrigins` 옵션을 사용할 수 있습니다.
+
+```yaml
+kubetail:
+  dashboard:
+    runtimeConfig:
+      allowedOrigins:
+        - https://kubetail.example.com
 ```
 </Aside>
 

--- a/src/content/docs/ko/guides/cluster/installation.mdx
+++ b/src/content/docs/ko/guides/cluster/installation.mdx
@@ -44,16 +44,7 @@ kubectl get pods -n kubetail-system
 
 ## 다음 단계
 
-Kubetail이 클러스터 안에서 실행되면 평소와 같이 `kubectl proxy` 또는 `kubectl port-forward`를 사용해 접근할 수 있습니다.
-
-* **`kubectl proxy`**
-
-  ```sh
-  kubectl proxy
-  ```
-
-  [http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/](http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/) 로 접속하세요.
-
+Kubetail이 클러스터 안에서 실행되면 평소와 같이 `kubectl port-forward` 같은 접근 방법을 사용할 수 있습니다.
 
 * **`kubectl port-forward`**
 
@@ -63,7 +54,7 @@ Kubetail이 클러스터 안에서 실행되면 평소와 같이 `kubectl proxy`
 
   [http://localhost:8080](http://localhost:8080) 로 접속하세요.
 
-Kubetail 웹 대시보드에 더 쉽게 접근하려면 Service 또는 Ingress로 노출할 수도 있습니다.
+Kubetail 웹 대시보드에 더 쉽게 접근하려면 `Ingress` 또는 `GatewayAPI` 라우트를 사용해 노출할 수도 있습니다([Ingress](/ko/guides/cluster/ingress) 참고).
 
 Kubetail Dashboard에 대한 자세한 내용은 [여기 문서](/ko/concepts/gui-overview)를 참고하세요.
 

--- a/src/content/docs/ko/reference/cluster-api.mdx
+++ b/src/content/docs/ko/reference/cluster-api.mdx
@@ -152,20 +152,6 @@ cluster-api --config /etc/kubetail/cluster-api.yaml
         #
         server-name: ""
 
-    ## csrf ##
-    #
-    # CSRF 보호 설정
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # CSRF 보호를 활성화할지 여부입니다.
-      #
-      # 기본값: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # API 서버 로그 출력 설정

--- a/src/content/docs/ko/reference/dashboard.mdx
+++ b/src/content/docs/ko/reference/dashboard.mdx
@@ -65,6 +65,27 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     allowed-namespaces: []
 
+    ## allowed-origins ##
+    #
+    # WebSocket 업그레이드 요청에서 same-origin 외에 추가로 허용할 origin
+    # 목록입니다. 각 항목은 fully-qualified origin이어야 하며 —
+    # scheme://host[:port] 형식으로 path는 포함하지 않습니다. 비교는 host에
+    # 대해 대소문자를 구분하지 않으며 기본 포트를 정규화합니다(예:
+    # https://example.com 은 https://example.com:443 과 일치합니다).
+    #
+    # Host를 재작성하거나 scheme을 보존하지 않은 채 TLS를 종료하는 리버스
+    # 프록시 뒤에서 dashboard를 실행할 때 사용하세요 — 이 경우 r.Host/r.TLS
+    # 기반의 직접적인 same-origin 매칭은 정상적인 브라우저 요청을 거부할
+    # 수 있습니다. dashboard가 외부에 노출되는 origin을 나열하세요.
+    #
+    # 예시:
+    #   - https://kubetail.example.com
+    #   - https://kubetail.example.com:8443
+    #
+    # 기본값: []
+    #
+    allowed-origins: []
+
     ## kubeconfig ##
     #
     # Kubernetes API 요청에 사용할 kubeconfig 파일 경로입니다.
@@ -126,20 +147,6 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     gin-mode: release
 
-    ## csrf ##
-    #
-    # CSRF 보호 설정
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # CSRF 보호를 활성화할지 여부입니다.
-      #
-      # 기본값: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # dashboard server 로그 출력 설정
@@ -200,15 +207,20 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     session:
 
-      ## secret ##
+      ## key-pairs ##
       #
-      # 세션 토큰 서명에 사용하는 비밀 키입니다.
-      # 비어 있으면 시작 시 임의의 secret이 생성되며(세션은
-      # 재시작 후 유지되지 않습니다).
+      # 세션 쿠키용 서명/암호화 키 쌍입니다. 첫 번째 쌍은 새 쿠키를 만드는
+      # 데 사용되고, 추가 쌍은 읽기 전용으로 허용되어 무중단 키 로테이션을
+      # 가능하게 합니다.
       #
-      # 기본값: ""
+      # 각 쌍은 다음 항목을 가집니다.
+      #   signing-key    (필수) — hex 인코딩된 HMAC 서명 키. 32 또는 64 raw 바이트 권장
+      #   encryption-key (선택) — hex 인코딩된 AES 암호화 키. 16, 24 또는 32 raw 바이트
       #
-      secret: ""
+      # 비어 있고 local-storage-dir이 설정된 경우, 첫 시작 시 임의의 키
+      # 쌍이 생성되어 디스크에 저장됩니다.
+      #
+      key-pairs: []
 
       ## cookie ##
       #

--- a/src/content/docs/pt/guides/cluster/ingress.mdx
+++ b/src/content/docs/pt/guides/cluster/ingress.mdx
@@ -86,7 +86,7 @@ kubetail:
 ```
 
 <Aside type="tip">
-Ao servir o Dashboard por HTTPS, defina `session.cookie.secure: true` na `runtimeConfig` do Dashboard para que o cookie de sessao seja transmitido apenas por conexoes seguras:
+Ao servir o Dashboard por HTTPS, defina `session.cookie.secure: true` na `runtimeConfig` do Dashboard para que o cookie de sessao seja transmitido apenas por conexoes seguras. Tambem e uma boa pratica usar o prefixo `__Host-` no nome do cookie.
 
 ```yaml
 kubetail:
@@ -94,7 +94,20 @@ kubetail:
     runtimeConfig:
       session:
         cookie:
+          name: __Host-session
           secure: true
+```
+</Aside>
+
+<Aside type="tip">
+Quando voce implanta o Dashboard atras de um proxy, algumas requisicoes podem falhar nas verificacoes de same-origin (por exemplo, se host ≠ origin) e ser rejeitadas (por exemplo, conexoes WebSocket). Para resolver isso, voce pode usar a opcao `allowedOrigins`:
+
+```yaml
+kubetail:
+  dashboard:
+    runtimeConfig:
+      allowedOrigins:
+        - https://kubetail.example.com
 ```
 </Aside>
 

--- a/src/content/docs/pt/guides/cluster/installation.mdx
+++ b/src/content/docs/pt/guides/cluster/installation.mdx
@@ -44,16 +44,7 @@ kubectl get pods -n kubetail-system
 
 ## Proximos passos
 
-Depois que o Kubetail estiver rodando dentro do cluster, voce podera acessa-lo usando os metodos habituais, como `kubectl proxy` ou `kubectl port-forward`:
-
-* **`kubectl proxy`**
-
-  ```sh
-  kubectl proxy
-  ```
-
-  Acesse [http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/](http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/)
-
+Depois que o Kubetail estiver rodando dentro do cluster, voce podera acessa-lo usando os metodos habituais, como `kubectl port-forward`:
 
 * **`kubectl port-forward`**
 
@@ -63,7 +54,7 @@ Depois que o Kubetail estiver rodando dentro do cluster, voce podera acessa-lo u
 
   Acesse [http://localhost:8080](http://localhost:8080)
 
-Voce tambem pode expor o dashboard web do Kubetail usando um service ou um ingress para facilitar o acesso.
+Para facilitar o acesso ao dashboard web do Kubetail, voce tambem pode expo-lo usando uma rota `Ingress` ou `GatewayAPI` (consulte [Ingress](/pt/guides/cluster/ingress)).
 
 Para mais informacoes sobre o Dashboard do Kubetail, consulte a documentacao [aqui](/pt/concepts/gui-overview).
 

--- a/src/content/docs/pt/reference/cluster-api.mdx
+++ b/src/content/docs/pt/reference/cluster-api.mdx
@@ -152,20 +152,6 @@ cluster-api --config /etc/kubetail/cluster-api.yaml
         #
         server-name: ""
 
-    ## csrf ##
-    #
-    # Configuracoes de protecao CSRF
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # Indica se a protecao CSRF esta habilitada.
-      #
-      # Valor padrao: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # Configuracao da saida de logs do servidor API

--- a/src/content/docs/pt/reference/dashboard.mdx
+++ b/src/content/docs/pt/reference/dashboard.mdx
@@ -65,6 +65,28 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     allowed-namespaces: []
 
+    ## allowed-origins ##
+    #
+    # Origens adicionais (alem de same-origin) aceitas em requisicoes de
+    # upgrade WebSocket. Cada entrada deve ser uma origem totalmente
+    # qualificada — scheme://host[:port] sem caminho. A comparacao e
+    # case-insensitive no host e normaliza portas padrao (assim
+    # https://example.com corresponde a https://example.com:443).
+    #
+    # Use isto ao executar o dashboard atras de um proxy reverso que
+    # reescreve Host ou termina TLS sem preservar o scheme — a
+    # correspondencia direta de same-origin contra r.Host/r.TLS rejeitaria,
+    # de outra forma, requisicoes legitimas do navegador. Liste a(s)
+    # origem(ns) publica(s) em que o dashboard e servido.
+    #
+    # Exemplos:
+    #   - https://kubetail.example.com
+    #   - https://kubetail.example.com:8443
+    #
+    # Valor padrao: []
+    #
+    allowed-origins: []
+
     ## kubeconfig ##
     #
     # Caminho para o arquivo kubeconfig usado em requisicoes para a API do Kubernetes.
@@ -126,20 +148,6 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     gin-mode: release
 
-    ## csrf ##
-    #
-    # Configuracoes de protecao CSRF
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # Indica se a protecao CSRF esta habilitada.
-      #
-      # Valor padrao: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # Configuracao da saida de logs do servidor dashboard
@@ -200,15 +208,21 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     session:
 
-      ## secret ##
+      ## key-pairs ##
       #
-      # A chave secreta usada para assinar tokens de sessao.
-      # Se estiver vazia, um secret aleatorio sera gerado na inicializacao (as sessoes nao
-      # sobreviverao a reinicializacoes).
+      # Um ou mais pares de chaves de assinatura/criptografia para cookies de
+      # sessao. O primeiro par e usado para novos cookies; pares adicionais
+      # sao aceitos somente para leitura, permitindo rotacao de chaves sem
+      # tempo de inatividade.
       #
-      # Valor padrao: ""
+      # Cada par tem:
+      #   signing-key    (obrigatorio) — chave HMAC de assinatura em hex; recomenda-se 32 ou 64 bytes brutos
+      #   encryption-key (opcional)    — chave AES de criptografia em hex; 16, 24 ou 32 bytes brutos
       #
-      secret: ""
+      # Quando vazio e um local-storage-dir esta configurado, um par
+      # aleatorio e gerado e persistido em disco na primeira inicializacao.
+      #
+      key-pairs: []
 
       ## cookie ##
       #

--- a/src/content/docs/zh-cn/guides/cluster/ingress.mdx
+++ b/src/content/docs/zh-cn/guides/cluster/ingress.mdx
@@ -86,7 +86,7 @@ kubetail:
 ```
 
 <Aside type="tip">
-当您通过 HTTPS 提供 Dashboard 时，请在 Dashboard 的 `runtimeConfig` 中设置 `session.cookie.secure: true`，这样会话 Cookie 只会通过安全连接传输：
+当您通过 HTTPS 提供 Dashboard 时，请在 Dashboard 的 `runtimeConfig` 中设置 `session.cookie.secure: true`，这样会话 Cookie 只会通过安全连接传输。同时，建议为 cookie 名称使用 `__Host-` 前缀。
 
 ```yaml
 kubetail:
@@ -94,7 +94,20 @@ kubetail:
     runtimeConfig:
       session:
         cookie:
+          name: __Host-session
           secure: true
+```
+</Aside>
+
+<Aside type="tip">
+当您将 Dashboard 部署在代理后面时，部分请求可能因 same-origin 校验失败（例如 host ≠ origin）而被拒绝（例如 WebSocket 连接）。您可以使用 `allowedOrigins` 选项来解决这个问题：
+
+```yaml
+kubetail:
+  dashboard:
+    runtimeConfig:
+      allowedOrigins:
+        - https://kubetail.example.com
 ```
 </Aside>
 

--- a/src/content/docs/zh-cn/guides/cluster/installation.mdx
+++ b/src/content/docs/zh-cn/guides/cluster/installation.mdx
@@ -44,16 +44,7 @@ kubectl get pods -n kubetail-system
 
 ## 后续步骤
 
-当 Kubetail 在集群内部运行后，您可以像平常一样通过 `kubectl proxy` 或 `kubectl port-forward` 访问它：
-
-* **`kubectl proxy`**
-
-  ```sh
-  kubectl proxy
-  ```
-
-  访问 [http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/](http://localhost:8001/api/v1/namespaces/kubetail-system/services/kubetail-dashboard:8080/proxy/)
-
+当 Kubetail 在集群内部运行后，您可以使用常见的访问方式（例如 `kubectl port-forward`）访问它：
 
 * **`kubectl port-forward`**
 
@@ -63,7 +54,7 @@ kubectl get pods -n kubetail-system
 
   访问 [http://localhost:8080](http://localhost:8080)
 
-您也可以通过 Service 或 Ingress 暴露 Kubetail Web 仪表板，以便更方便地访问。
+为了更方便地访问 Kubetail Web 仪表板，您也可以通过 `Ingress` 或 `GatewayAPI` 路由将其暴露出去（参见 [Ingress](/zh-cn/guides/cluster/ingress)）。
 
 有关 Kubetail Dashboard 的更多信息，请查看[此处文档](/zh-cn/concepts/gui-overview)。
 

--- a/src/content/docs/zh-cn/reference/cluster-api.mdx
+++ b/src/content/docs/zh-cn/reference/cluster-api.mdx
@@ -152,20 +152,6 @@ cluster-api --config /etc/kubetail/cluster-api.yaml
         #
         server-name: ""
 
-    ## csrf ##
-    #
-    # CSRF 保护设置
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # 是否启用 CSRF 保护。
-      #
-      # 默认值: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # API 服务器日志输出配置

--- a/src/content/docs/zh-cn/reference/dashboard.mdx
+++ b/src/content/docs/zh-cn/reference/dashboard.mdx
@@ -65,6 +65,26 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     allowed-namespaces: []
 
+    ## allowed-origins ##
+    #
+    # 在 WebSocket 升级请求中接受的额外 origin（在 same-origin 之外）。
+    # 每一项必须是完整的 origin —— scheme://host[:port]，不能包含路径。
+    # 比较时 host 不区分大小写，并会归一化默认端口（即 https://example.com
+    # 与 https://example.com:443 相匹配）。
+    #
+    # 当 dashboard 部署在反向代理之后，且代理重写了 Host 或终止了 TLS
+    # 而没有保留 scheme 时，请使用此选项 —— 否则直接基于 r.Host/r.TLS
+    # 进行 same-origin 匹配会拒绝合法的浏览器请求。请列出 dashboard
+    # 对外提供服务的 origin。
+    #
+    # 示例:
+    #   - https://kubetail.example.com
+    #   - https://kubetail.example.com:8443
+    #
+    # 默认值: []
+    #
+    allowed-origins: []
+
     ## kubeconfig ##
     #
     # Kubernetes API 请求使用的 kubeconfig 文件路径。
@@ -126,20 +146,6 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     gin-mode: release
 
-    ## csrf ##
-    #
-    # CSRF 保护设置
-    #
-    csrf:
-
-      ## enabled ##
-      #
-      # 是否启用 CSRF 保护。
-      #
-      # 默认值: true
-      #
-      enabled: true
-
     ## logging ##
     #
     # dashboard server 的日志输出配置
@@ -200,15 +206,20 @@ dashboard --config /etc/kubetail/dashboard.yaml
     #
     session:
 
-      ## secret ##
+      ## key-pairs ##
       #
-      # 用于签名会话 token 的密钥。
-      # 如果为空，则会在启动时生成一个随机 secret（会话不会
-      # 跨重启保留）。
+      # 用于会话 cookie 的一个或多个签名/加密密钥对。第一个密钥对
+      # 用于生成新 cookie；其他密钥对仅用于读取，从而支持零停机
+      # 时间的密钥轮换。
       #
-      # 默认值: ""
+      # 每个密钥对包含:
+      #   signing-key    （必填）— 十六进制编码的 HMAC 签名密钥；建议使用 32 或 64 字节的原始字节
+      #   encryption-key （可选）— 十六进制编码的 AES 加密密钥；可为 16、24 或 32 字节的原始字节
       #
-      secret: ""
+      # 当此项为空且配置了 local-storage-dir 时，会在首次启动时
+      # 生成一个随机密钥对并持久化到磁盘。
+      #
+      key-pairs: []
 
       ## cookie ##
       #


### PR DESCRIPTION
Ref #56

## Summary

The previous PR (#56) updated the English docs for the new `allowed-origins` option and the `session.key-pairs` rename, but the translation files were missed. This PR brings the seven non-English locales (de, es, fr, ja, ko, pt, zh-cn) back in sync with the English source.

## Key Changes

- `guides/cluster/ingress.mdx`: add `__Host-` cookie-name guidance and a new `allowedOrigins` Aside for proxy deployments.
- `guides/cluster/installation.mdx`: drop the `kubectl proxy` bullet and link to the Ingress guide for exposure options.
- `reference/cluster-api.mdx`: remove the obsolete `csrf` block from the YAML config.
- `reference/dashboard.mdx`: add `allowed-origins`, remove `csrf`, and replace `session.secret` with `session.key-pairs`.

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused